### PR TITLE
Use bufio.ReadString instead of fmt.Scanln so that spaces are handled

### DIFF
--- a/prompt.go
+++ b/prompt.go
@@ -1,16 +1,20 @@
 package prompt
 
-import "github.com/howeyc/gopass"
-import "strings"
-import "strconv"
-import "fmt"
+import (
+    "bufio"
+    "fmt"
+    "github.com/howeyc/gopass"
+    "os"
+    "strconv"
+    "strings"
+)
 
 // String prompt.
 func String(prompt string, args ...interface{}) string {
-	var s string
 	fmt.Printf(prompt+": ", args...)
-	fmt.Scanln(&s)
-	return s
+	reader := bufio.NewReader(os.Stdin)
+	bytes, _, _ := reader.ReadLine()
+	return string(bytes)
 }
 
 // String prompt (required).


### PR DESCRIPTION
I've changed the import as previous discussion on PR 
